### PR TITLE
add .ipynb_checkpoints/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *~
 \#*\#
-
+.ipynb_checkpoints/


### PR DESCRIPTION
This pull request adds .ipynb_checkpoints/ to .gitignore and thus prevents spamming the git log with jupyter notebook internals.